### PR TITLE
Fix: 이미지 삭제 기능 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### custom ###
+application-s3.properties

--- a/src/main/java/com/example/cloneinstagram/board/entity/Board.java
+++ b/src/main/java/com/example/cloneinstagram/board/entity/Board.java
@@ -2,6 +2,7 @@ package com.example.cloneinstagram.board.entity;
 
 import com.example.cloneinstagram.board.dto.BoardRequestDto;
 import com.example.cloneinstagram.common.Timestamped;
+import com.example.cloneinstagram.love.entity.BoardLove;
 import com.example.cloneinstagram.member.entity.Member;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -21,6 +24,9 @@ public class Board extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "board_id")
     private Long id;
+
+    @Column
+    private String imageName;
 
     @Column(length = 500, nullable = false)
     private String imageUrl;
@@ -36,8 +42,12 @@ public class Board extends Timestamped {
     @JsonBackReference
     private Member member;
 
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
+    private List<BoardLove> boardLoveList = new ArrayList<>();
+
     @Builder
-    public Board(String imageUrl, String contents, Member member) {
+    public Board(String imageName, String imageUrl, String contents, Member member) {
+        this.imageName = imageName;
         this.imageUrl = imageUrl;
         this.contents = contents;
         this.member = member;

--- a/src/main/java/com/example/cloneinstagram/board/service/BoardService.java
+++ b/src/main/java/com/example/cloneinstagram/board/service/BoardService.java
@@ -1,7 +1,10 @@
 package com.example.cloneinstagram.board.service;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.cloneinstagram.board.dto.BoardRequestDto;
@@ -69,6 +72,7 @@ public class BoardService {
         imageUrl = amazonS3Client.getUrl(bucketName, imageName).toString();
 
         board = Board.builder()
+                .imageName(imageName)
                 .imageUrl(imageUrl)
                 .contents(boardRequestDto.getContents())
                 .member(userDetails.getUser())
@@ -93,6 +97,7 @@ public class BoardService {
     public ResponseMsgDto<?> deletePost(Long id, Member member) {
         matchAuthor(id, member);
         board = existBoard(id);
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucketName, board.getImageName()));
         boardRepository.deleteById(id);
         return ResponseMsgDto.setSuccess(HttpStatus.OK.value(), "게시글 삭제 완료", null);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,8 +14,7 @@ jwt.secret.key:ENC(iwFwrLoo/R1zEB9oexxRMORMOTEjdTKZfLCFTuaUzG8baUjT7cYfKQUd/QY74
 #S3
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.s3.bucket=clone-instagram-bucket
-cloud.aws.credentials.access-key=AKIA2CRGHEGLS7BXIYU6
-cloud.aws.credentials.secret-key=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
+spring.profiles.include=s3
 
 cloud.aws.stack.auto=false
 spring.servlet.multipart.max-file-size=10MB


### PR DESCRIPTION
1. S3에서도 이미지 삭제되도록 수정
2. Board 테이블에 삭제에 필요한 키값인 imageName 추가
3. 좋아요 있는 게시글 삭제되도록 OneToMany로 양방향 매핑 설정
4. s3 키값 properties 분리 및 .gitignore에 추가